### PR TITLE
Python 3.9 compatibility

### DIFF
--- a/mymcplus/ps2mc.py
+++ b/mymcplus/ps2mc.py
@@ -94,17 +94,17 @@ if sys.byteorder == "big":
     def pack_32bit_array(a):
         a = a[:]
         a.byteswap()
-        return a.tostring()
+        return a.tobytes()
 else:
     def unpack_32bit_array(s):
         #if isinstance(s, str):
         #    a = array.array('L')
-        #    a.fromstring(s)
+        #    a.frombytes(s)
         #    return a
         return array.array('I', s)
 
     def pack_32bit_array(a):
-        return a.tostring()
+        return a.tobytes()
     
 def unpack_superblock(s):
     sb = struct.unpack("<28s12sHHHHLLLLLL8x128s128sbbxx", s)

--- a/mymcplus/ps2mc_ecc.py
+++ b/mymcplus/ps2mc_ecc.py
@@ -69,7 +69,7 @@ def _ecc_calculate(s):
 
     if not isinstance(s, array.array):
         a = array.array('B')
-        a.fromstring(s)
+        a.frombytes(s)
         s = a
     column_parity = 0x77
     line_parity_0 = 0x7F
@@ -95,7 +95,7 @@ def _ecc_check(s, ecc):
         return ECC_CHECK_OK
 
     #print
-    #_print_bin(0, s.tostring())
+    #_print_bin(0, s.tobytes())
     #print "computed %02x %02x %02x" % tuple(computed)
     #print "actual %02x %02x %02x" % tuple(ecc)
 
@@ -148,7 +148,7 @@ def ecc_check_page(page, spare):
     chunks = []
     for i in range(div_round_up(len(page), 128)):
         a = array.array('B')
-        a.fromstring(page[i * 128 : i * 128 + 128])
+        a.frombytes(page[i * 128 : i * 128 + 128])
         chunks.append((a, list(spare[i * 3 : i * 3 + 3])))
 
     r = [ecc_check(s, ecc)
@@ -156,7 +156,7 @@ def ecc_check_page(page, spare):
     ret = ECC_CHECK_OK
     if ECC_CHECK_CORRECTED in r:
         # rebuild sector and spare from the corrected versions
-        page = b"".join([a[0].tostring() for a in chunks])
+        page = b"".join([a[0].tobytes() for a in chunks])
         spare = bytes([a[1][i]
                        for a in chunks
                        for i in range(3)])

--- a/mymcplus/save/lzari.py
+++ b/mymcplus/save/lzari.py
@@ -98,7 +98,7 @@ def bit_array_to_string(a):
     remainder = len(a) % 8
     if remainder != 0:
         a.fromlist([0] * (8 - remainder))
-    s = a.tostring()
+    s = a.tobytes()
     s = binascii.unhexlify(s.translate(_tr_rev_2))
     s = binascii.unhexlify(s.translate(_tr_rev_4))
     return binascii.unhexlify(s.translate(_tr_rev_16))
@@ -632,7 +632,7 @@ class lzari_codec(object):
         self.in_iter = None
         if progress:
             sys.stderr.write("%s100%%\n" % progress)
-        return out.tostring()
+        return out.tobytes()
 
 if mymcsup == None:
     def decode(src, out_length, progress = None):

--- a/test/test_ecc.py
+++ b/test/test_ecc.py
@@ -51,7 +51,7 @@ def test_ecc_check_ok():
     res = ps2mc_ecc.ecc_check(s, ecc)
 
     assert res == ps2mc_ecc.ECC_CHECK_OK
-    assert s.tostring() == bytes(_data)
+    assert s.tobytes() == bytes(_data)
     assert ecc == _ecc
 
 
@@ -65,7 +65,7 @@ def test_ecc_check_correct_data():
     res = ps2mc_ecc.ecc_check(s, ecc)
 
     assert res == ps2mc_ecc.ECC_CHECK_CORRECTED
-    assert s.tostring() == bytes(_data)
+    assert s.tobytes() == bytes(_data)
     assert ecc == _ecc
 
 
@@ -79,7 +79,7 @@ def test_ecc_check_correct_ecc():
     res = ps2mc_ecc.ecc_check(s, ecc)
 
     assert res == ps2mc_ecc.ECC_CHECK_CORRECTED
-    assert s.tostring() == bytes(_data)
+    assert s.tobytes() == bytes(_data)
     assert ecc == _ecc
 
 


### PR DESCRIPTION
array.fromstring(s) and array.tostring(s) were deprecatd in Python 3.2 and removed in Python 3.9
https://docs.python.org/3.9/whatsnew/3.9.html#removed